### PR TITLE
Cluster17 Update :: Load Screen Music Volume Reduced

### DIFF
--- a/configs/cluster17.cfg
+++ b/configs/cluster17.cfg
@@ -1,5 +1,5 @@
 loading_screen_music = "https://files.op-framework.com/files/hiddenHillsLA/hiddenhillslaloading.mp3"
-loading_screen_music_volume = 0.3
+loading_screen_music_volume = 0.2  # Music is extremely load. I have volume for Chromium barely up and it's blasting. Changed from 3 to 2 for testing.
 
 allow_crosshair = false
 


### PR DESCRIPTION
The music for the load screen has been complained about being way too loud. I have to agree as My Fivem Chromium is barely turned up and it's still load for me.