### PR TITLE
Cluster17 Update :: Cargo and Drugs

### DIFF
--- a/configs/cluster17.cfg
+++ b/configs/cluster17.cfg
@@ -17,9 +17,9 @@ npcs_call_ems = true
 
 drug_sale_minimum_police = 3   # Added to compensate grinding drugs without consequences. Changed to 2 on 7/10. Have more PD in the server now.
 drug_sale_minimum_police_multiplier = true
-weed_sale_multiplier = 1.4   # Normally 1.3 :: Changed to compensate just grinding illegal sale without consequence
-cocaine_sale_multiplier = 1.4   # Normally 1.3 :: Changed to compensate just grinding illegal sale without consequence
-cargo_minimum_players = 20      # Added to prevent people doing this without having to worry about other gangs while still small.
+weed_sale_multiplier = 1.0   # Normally 1.3 :: Changed to compensate just grinding illegal sale without consequence
+cocaine_sale_multiplier = 1.0   # Normally 1.3 :: Changed to compensate just grinding illegal sale without consequence
+cargo_minimum_players = 200    #Gangs have been merging together, making it so that there is 1 large gang instead of multiple smaller ones. Once gangs reduce in size and there are more, will re-enable. 
 
 admin_panel_url = https://c17.opframework.com
 


### PR DESCRIPTION
Drug sales reduced to help while PD gets on their feet with size without drugs being sold without response.  Cargo increased to 200 due to gangs merging into 1 large one(don't know why). Will be setting a gang member limit. Once the gangs have split and created new gangs, this will be reverted. Right now it's just 1 gang abusing it.