### PR TITLE
C17 : Gun Running, Weapon Licenses, Robberies.

### DIFF
--- a/configs/cluster17.cfg
+++ b/configs/cluster17.cfg
@@ -13,6 +13,9 @@ disable_aim_roll = true
 store_robberies_required_police = 2 # Default 3
 jewelry_heist_required_police = 4 # Default is 6
 
+disable_guns = true #Duy request this to prevent prior legacy players from moving over and abusing information. Will be false in 3 days time(August 2-3).
+
+
 npcs_call_ems = true
 
 drug_sale_minimum_police = 3   # Added to compensate grinding drugs without consequences. Changed to 2 on 7/10. Have more PD in the server now.
@@ -26,6 +29,10 @@ admin_panel_url = https://c17.opframework.com
 police_mdt_source = https://mdt.morningbelle.lol/
 
 allow_n_word = true
+
+store_override = "gun_store=weapon_flashlight:-1,weapon_bottle:-1,weapon_crowbar:-1,weapon_battleaxe:-1,weapon_nightstick:-1,weapon_stone_hatchet:-1,weapon_hatchet:-1,sub_ammo:-1,"
+
+requires_weapon_license = "weapon_ceramicpistol,weapon_combatpistol,weapon_addon_dp9,weapon_addon_endurancepistol,weapon_heavypistol,weapon_marksmanpistol,weapon_gadgetpistol,weapon_pistol,weapon_pistol50,weapon_pistol_mk2,weapon_addon_dutypistol,weapon_snspistol,weapon_snspistol_mk2,weapon_addon_vfcombatpistol,weapon_vintagepistol,weapon_pistolxm3,weapon_assaultshotgun,weapon_addon_seninelbbshotgun,weapon_bullpupshotgun,weapon_combatshotgun,weapon_dbshotgun,weapon_heavyshotgun,weapon_pumpshotgun,weapon_pumpshotgun_mk2,weapon_addon_680,weapon_addon_m870,weapon_addon_sawnoffshotgun,weapon_addon_sentinelshotgun,weapon_autoshotgun,weapon_addon_huntingrifle,pistol_ammo,rifle_ammo,shotgun_ammo,sniper_ammo,"
 
 job_overrides = "Law Enforcement:SASP:Cadet=90;Probationary Trooper=100;Trooper=110;Senior Trooper=115;Lance Corporal=120;Corporal=125;Senior Corporal=130;Sergeant=140;Sergeant First class=150;Master Sergeant=160;Lieutenant=170;Captain=180;Major=190;Deputy Chief=200;Assistant Chief=210;Chief=220,Law Enforcement:SAHP:Cadet=15,Medical:Los Santos Medical Center:EMR=104;EMT=116;Senior EMT=128;Paramedic=140;Senior Paramedic=152;Lieutenant=164;Captain=176;Asisstant Chief=188;Chief=200;Director=200"
 #Changed Medical to reflect Fire Department until we grow to have doctors and nurses

--- a/configs/cluster17.cfg
+++ b/configs/cluster17.cfg
@@ -10,8 +10,8 @@ recoil_vehicle_fire_multiplier = 2.0 # Will be adjusting to find the balance
 
 disable_aim_roll = true
 
-store_robberies_required_police = 2 # Default 3
-jewelry_heist_required_police = 4 # Default is 6
+store_robberies_required_police = 3 # Default 3
+jewelry_heist_required_police = 6 # Default is 6
 
 disable_guns = true #Duy request this to prevent prior legacy players from moving over and abusing information. Will be false in 3 days time(August 2-3).
 


### PR DESCRIPTION
Disabling gun running to prevent prior legacy players from coming in and using legacy knowledge to power their way through getting equipment without RPing with the already established gangs. This will be a temporary change(for about 3 days).

Added weapons license to further RP with PD. This will also reduced the amount of RDMs going on when the server is boosted.

With the amount of PD around, it felt right to bring the robberies minimum back to default. 