### PR TITLE
C17 : Cargo Min Increase

### DIFF
--- a/configs/cluster17.cfg
+++ b/configs/cluster17.cfg
@@ -24,7 +24,7 @@ drug_sale_minimum_police = 3   # Added to compensate grinding drugs without cons
 drug_sale_minimum_police_multiplier = true
 weed_sale_multiplier = 1.0   # Normally 1.3 :: Changed to compensate just grinding illegal sale without consequence
 cocaine_sale_multiplier = 1.0   # Normally 1.3 :: Changed to compensate just grinding illegal sale without consequence
-cargo_minimum_players = 50    #Gangs have been merging together, making it so that there is 1 large gang instead of multiple smaller ones. Once gangs reduce in size and there are more, will re-enable. 
+cargo_minimum_players = 500    #Gangs have been merging together, making it so that there is 1 large gang instead of multiple smaller ones. Once gangs reduce in size and there are more, will re-enable. 
 
 
 lock_los_santos_customs = true  #Midnight tuners is requesting more business

--- a/configs/cluster24.cfg
+++ b/configs/cluster24.cfg
@@ -1,7 +1,7 @@
 loading_screen_music = "https://files.op-framework.com/files/rhw/GK4jorZHSKw.mp3"
 loading_screen_music_volume = 0.1
 
-
+allow_n_word = true
 
 lock_los_santos_customs = true 
  


### PR DESCRIPTION
Set Cargo to ridiculous size. 
Only staff can trigger based on gang members in a VC, to trigger cargo when the most amount of gangs / gang members are available.