### PR TITLE
C17 :: Exclusion, FIB

### DIFF
--- a/configs/cluster17.cfg
+++ b/configs/cluster17.cfg
@@ -7,7 +7,7 @@ loading_screen_music_volume = 0.1  # Music is extremely load. I have volume for 
 allow_crosshair = true
 
 firing_stress_increase_multiplier = 1.5  # Increased as 1 seems a little too low. Shooting lots doesn't seem to be affected as much as i thought.
-
+recoil_hip_fire_multiplier = 2.5 # Increase recoil when hip firing
 disable_third_person_vehicle_aim = true
 recoil_vehicle_fire_multiplier = 2.0 # Will be adjusting to find the balance
 
@@ -24,11 +24,12 @@ drug_sale_minimum_police = 3   # Added to compensate grinding drugs without cons
 drug_sale_minimum_police_multiplier = true
 weed_sale_multiplier = 1.0   # Normally 1.3 :: Changed to compensate just grinding illegal sale without consequence
 cocaine_sale_multiplier = 1.0   # Normally 1.3 :: Changed to compensate just grinding illegal sale without consequence
-cargo_minimum_players = 500    #Gangs have been merging together, making it so that there is 1 large gang instead of multiple smaller ones. Once gangs reduce in size and there are more, will re-enable. 
+cargo_minimum_players = 500  
 
 
 lock_los_santos_customs = true  #Midnight tuners is requesting more business
 
+excluded_jobs = "6" #Excluding Tow Driver job, people are abusing it to access other people's shops / misuse customs to avoid tuner shops(even thouhg customs is locked to general populace
 
 admin_panel_url = https://c17.opframework.com
 
@@ -40,4 +41,4 @@ store_overrides = "gun_store=weapon_flashlight:-1,weapon_bottle:-1,weapon_crowba
 
 requires_weapon_license = "weapon_ceramicpistol,weapon_combatpistol,weapon_addon_dp9,weapon_addon_endurancepistol,weapon_heavypistol,weapon_marksmanpistol,weapon_gadgetpistol,weapon_pistol,weapon_pistol50,weapon_pistol_mk2,weapon_addon_dutypistol,weapon_snspistol,weapon_snspistol_mk2,weapon_addon_vfcombatpistol,weapon_vintagepistol,weapon_pistolxm3,weapon_assaultshotgun,weapon_addon_seninelbbshotgun,weapon_bullpupshotgun,weapon_combatshotgun,weapon_dbshotgun,weapon_heavyshotgun,weapon_pumpshotgun,weapon_pumpshotgun_mk2,weapon_addon_680,weapon_addon_m870,weapon_addon_sawnoffshotgun,weapon_addon_sentinelshotgun,weapon_autoshotgun,pistol_ammo,rifle_ammo,shotgun_ammo,sniper_ammo,"
 
-job_overrides = "Law Enforcement:SASP:Cadet=88;Probationary Trooper=94;Trooper=100;Senior Trooper=106;Lance Corporal=112;Corporal=118;Senior Corporal=124;Sergeant=130;Sergeant First class=136;Master Sergeant=142;Lieutenant=148;Captain=154;Major=160;Deputy Chief=166;Assistant Chief=172;Chief=178,Law Enforcement:SAHP:Cadet=15,Law Enforcement:LSSD:Cadet=88;Probationary Deputy=94;Deputy=100;Senior Deputy=106;Corporal=118;Sergeant=130;Sergeant First class=136;Lieutenant=148;Captain=154;Major=160;Chief Deputy=166;Undersheriff=172;Sheriff=178,Medical:Los Santos Medical Center:EMR=104;EMT=116;Senior EMT=128;Paramedic=140;Senior Paramedic=152;Lieutenant=164;Captain=176;Asisstant Chief=188;Chief=200;Director=200,Journalist:Weazel News:Freelancer=20;Reporter=50;Camera Person=55;Manager=80"
+job_overrides = "Law Enforcement:SASP:Cadet=88;Probationary Trooper=94;Trooper=100;Senior Trooper=106;Lance Corporal=112;Corporal=118;Senior Corporal=124;Sergeant=130;Sergeant First class=136;Master Sergeant=142;Lieutenant=148;Captain=154;Major=160;Deputy Chief=166;Assistant Chief=172;Chief=178,Law Enforcement:SAHP:Cadet=15;Trainee=90;Agent=98;Senior Agent=105;Special Agent=112;Executive Agent=120;Supervisory Agent=128;Agent-in-Charge=136;Chief of Staff=145;Executive Director=155;Assistant Director=165;Deputy Director=175;Director=185,Law Enforcement:LSSD:Cadet=88;Probationary Deputy=94;Deputy=100;Senior Deputy=106;Corporal=118;Sergeant=130;Sergeant First class=136;Lieutenant=148;Captain=154;Major=160;Chief Deputy=166;Undersheriff=172;Sheriff=178,Medical:Los Santos Medical Center:EMR=104;EMT=116;Senior EMT=128;Paramedic=140;Senior Paramedic=152;Lieutenant=164;Captain=176;Asisstant Chief=188;Chief=200;Director=200,Journalist:Weazel News:Freelancer=20;Reporter=50;Camera Person=55;Manager=80"


### PR DESCRIPTION
Added FIB(Using SAHP to guarantee the ability to do PD stuff. Had Added LSSD but the job, even though marked as Law Enforcement, doesn't have normal PD access). Excluded Tow Driving as a Life Invader job. People have been abusing the job to access shops, as well as customs while it is locked to avoid using Midnight tuners.