### PR TITLE
Updated Config Cluster 29

### DIFF
--- a/configs/cluster29.cfg
+++ b/configs/cluster29.cfg
@@ -3,7 +3,7 @@ allow_crosshair = true
 #Loading Screen 
 show_loading_screen_title = true
 loading_screen_music = "https://cdn.discordapp.com/attachments/1197226661800841266/1197253242652999750/firstpersonshooter.mp3"
-loading_screen_music_volume  = "0.45"
+loading_screen_music_volume  = "0.25"
 
 #DRUGS MULTIPLIER
 #acid_sale_multiplier = 1.0 
@@ -25,7 +25,7 @@ bank_robbery_required_police = 4 #Default = 4
 disable_weed = false
 disable_cocaine = false
 disable_oxy = false
-disable_guns = true
+disable_guns = false
 
 disable_jail_jobs = false
 
@@ -39,7 +39,7 @@ enable_critical_hits = false # setting to true will allow for headshots to one-s
 
 enable_seasonal_weather = true # enables seasonal weather (snowy weathers in winter, for example)
 
-extend_view_modes = false # adds all the native view modes
+extend_view_modes = true # adds all the native view modes
 
 neutral_gangs = false # when set to true, it makes all NPC gang peds not shoot at you when aggravated
 
@@ -56,13 +56,13 @@ population_density_multiplier = 1.0
 excluded_jobs = "4"
 
 # replace or add new items into item stores
-store_overrides = "gun_store=weapon_stone_hatchet:-1,weapon_addon_glock:4250;grocery_store=water:8;"
+store_overrides = "gun_store=weapon_stone_hatchet:-1,weapon_addon_glock:4250,weapon_addon_colt:-1,weapon_addon_680:-1,weapon_nightstick:-1,weapon_battleaxe:-1,weapon_stone_hatchet:-1;grocery_store=water:8;"
 
 #GUN PLAY
 disable_aim_roll = false # disable this: https://gyazo.com/ec4b6b660a89d3ca8849810ad267fcb3
 disable_automatics_in_vehicles = true #Does what it says
 global_weapon_damage_multiplier = 1 # 0.9 makes every gun do 90% of its original damage
-firing_stress_increase_multiplier = 1
+firing_stress_increase_multiplier = 1.35
 
 recoil_bloom = false
 recoil_multiplier_heading = 1
@@ -112,7 +112,7 @@ cargo_minimum_players = 40
 requires_weapon_license = "weapon_pistol,weapon_vintagepistol,weapon_snspistol,weapon_addon_glock"
 
 # Create overrides for burglary drops - the original list looks like this as of the time writing: https://inzidiuz.com/Dwemqi.png
-#burglary_drop_overrides = "hamburger:10000,water:10000"
+burglary_drop_overrides = "hamburger:100,water:105,decryption_key_red:10,blue:10,decryption_key_green:10,chip:15"
 
 # Creates overrides for job positions & their salaries (I have a tool to quickly generate a list in this format, if you want it just DM @b.0 on discord)
 job_overrides = "Law Enforcement:SASP:Cadet=70;Probationary Trooper=78;Trooper=86;Senior Trooper=93;Lance Corporal=100;Corporal=110;Senior Corporal=117;Sergeant=124;Sergeant First class=130;Master Sergeant=137;Lieutenant=144;Captain=150;Major=158;Deputy Chief=165;Assistant Chief=170;Chief=190"
@@ -129,7 +129,7 @@ disable_ped_hold_ups = false
 disable_gun_trader = false
 
 # Time it takes before you can respawn to a hospital & if you should have a chance of losing items when you do so
-respawn_time = 300
+respawn_time = 240
 respawn_item_penalty = true
 
 # List of repair shops to disable (blip, workbench, repair spot)
@@ -139,7 +139,7 @@ respawn_item_penalty = true
 # 4 = harmony
 # 5 = paleto
 # 6 = mirror park
-#disabled_repair_shops = "2"
+disabled_repair_shops = "2"
 
 # Makes the default inventory key F2 instead of K (https://docs.fivem.net/docs/game-references/controls/)
 #control_overrides = "InventoryKey:289:F2:false:false"


### PR DESCRIPTION
- Remove 1851 Navy, Remove Remington 680 from ammunation
- Lowered loading screen music down
- Enabled Gun Running
- Adjusted burglary drops -> hamburger:100,water:105,decryption_key_red:10,blue:10,decryption_key_green:10,chip:15
- Reduced respawn time
- Disabling The Lost since its currently broken
- Increased Stress from firing
- Enable Extended View