### PR TITLE
Update cluster30.cfg

### DIFF
--- a/configs/cluster30.cfg
+++ b/configs/cluster30.cfg
@@ -4,19 +4,19 @@ npcs_call_ems = true
 
 population_density_multiplier = 0.65
 
-bank_robbery_cooldown = 35
+bank_robbery_cooldown = 30
 
 bank_robbery_required_police = 3
 
-jewelry_robbery_cooldown = 50
+jewelry_robbery_cooldown = 45
 
 jewelry_heist_required_police = 4
 
 store_robberies_required_police = 2
 
-store_robbery_cooldown = 20
+store_robbery_cooldown = 25
 
-character_slots = 6
+character_slots = 8
 
 # List of repair shops to disable (blip, workbench, repair spot)
 # 1 = mosleys


### PR DESCRIPTION
We've had to tweak the robbery timers again because, for some strange reason, they weren't updating properly after changes. So, what was happening is that there was only about a five-minute delay before someone could try to rob again. (Approved by Ryan and ShinySableye)